### PR TITLE
Fix crash when shadow is disabled

### DIFF
--- a/lib/src/main/java/com/shamanland/fab/FloatingActionButton.java
+++ b/lib/src/main/java/com/shamanland/fab/FloatingActionButton.java
@@ -307,7 +307,11 @@ public class FloatingActionButton extends ImageButton {
                 Drawable circle = layers.getDrawable(1);
 
                 if (shadow instanceof GradientDrawable) {
-                    ((GradientDrawable) shadow.mutate()).setGradientRadius(mShadow ? getShadowRadius(shadow, circle) : 0f);
+                    if (mShadow) {
+                        ((GradientDrawable) shadow.mutate()).setGradientRadius(getShadowRadius(shadow, circle));
+                    } else {
+                        shadow.setAlpha(0);
+                    }
                 }
 
                 if (circle instanceof GradientDrawable) {


### PR DESCRIPTION
setGradientRadius(0f) will throw IllegalArgumentException, make the shadow transparent instead
